### PR TITLE
Star overflow/generation fix and BTT button dynamic postion

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -299,7 +299,7 @@ h4 {
     position: fixed;
     bottom: 50px;
     right: 30px;
-    z-index: 99;
+    z-index: 50;
     font-size: 1rem;
     border: none;
     outline: none;
@@ -307,7 +307,7 @@ h4 {
     cursor: pointer;
     padding: 1px; 
     border-radius: 4px;
-    transition: 0.5s;
+    transition: border, text-shadow, opacity, .5s;
 }
 
 .btt-btn i {

--- a/assets/js/btt-btn.js
+++ b/assets/js/btt-btn.js
@@ -1,9 +1,33 @@
-// -------------------------------------------------------------------- Global State
+// --------------------------------------------------------------- Global State
 
 const scrollBtn = document.querySelector('.btt-btn');
 
-// -------------------------------------------------------------------- Go To Top Button
+// ------------------------------------------------------------------ Go To Top Button
+
+scrollBtnOrigin = window.getComputedStyle(scrollBtn).getPropertyValue("bottom");
+scrollBtnWidthOrigin = window.
+    getComputedStyle(scrollBtn).getPropertyValue("right");
 
 window.addEventListener('scroll', function () {
-    scrollBtn.classList.toggle('active', window.scrollY > 300);
+    const winHeight = window.innerHeight;
+    const footHeight = document.getElementsByTagName("footer")[0].offsetHeight;
+    const headHeight = document.getElementsByTagName("header")[0].offsetHeight;
+    const mainHeight = document.getElementsByTagName("main")[0].offsetHeight;
+    const totalHeight = mainHeight + footHeight + headHeight;
+    // scroll point at which button should move
+    let scrollTrigger = mainHeight - winHeight;
+    // position to move button to (dynamic)
+    let scrollAdjuster = window.scrollY + winHeight - totalHeight + footHeight;
+    if (document.getElementsByClassName("quizshow-container").length !== 0) {
+        quizSect = document.getElementsByClassName("quizshow-container")[0];
+        scrollTrigger = mainHeight - quizSect.offsetHeight - winHeight;
+        scrollAdjuster = scrollAdjuster + quizSect.offsetHeight;
+    }
+    scrollBtn.classList.toggle('active', window.scrollY > 1);
+    if (window.scrollY > scrollTrigger) {
+        scrollBtn.style.bottom = `
+            ${scrollAdjuster + 2 * scrollBtn.offsetHeight}px`;
+    } else {
+        scrollBtn.style.bottom = scrollBtnOrigin;
+    }
 });

--- a/assets/js/index.js
+++ b/assets/js/index.js
@@ -1,50 +1,129 @@
-// -------------------------------------------------------------------- Global State
+// ---------------------------------------------------------------- Global State
 
-const stars = document.getElementsByClassName("christmas-star");
-const currentStars = [];
+const stars = [
+    `
+    <a href="christmas.html" class="christmas-star">
+        <span class="sr-only">Christmas</span>
+        <div class="star tap-target tooltip">
+            <span class="tooltiptext">Christmas</span>
+        </div>
+    </a>
+    `,
+    `
+    <a href="hanukkah.html" class="christmas-star">
+        <span class="sr-only">Hanukkah</span>
+        <div class="star tap-target tooltip">
+            <span class="tooltiptext">Hanukkah</span>
+        </div>
+    </a>
+    `,
+    `
+    <a href="diwali.html" class="christmas-star">
+        <span class="sr-only">Diwali</span>
+        <div class="star tap-target tooltip">
+            <span class="tooltiptext">Diwali</span>
+        </div>
+    </a>
+    `,
+    `
+    <a href="chinese-new-year.html" class="christmas-star">
+        <span class="sr-only">Chinese New Year</span>
+        <div class="star tap-target tooltip">
+            <span class="tooltiptext">Chinese New Year</span>
+        </div>
+    </a>
+    `,
+    `
+    <a href="new-year.html" class="christmas-star">
+        <span class="sr-only">New Year's Eve</span>
+        <div class="star tap-target tooltip">
+            <span class="tooltiptext">New Year's Eve</span>
+        </div>
+    </a>
+    `,
+    `
+    <a href="yuletide.html" class="christmas-star">
+        <span class="sr-only">Yuletide</span>
+        <div class="star tap-target tooltip">
+            <span class="tooltiptext">Yuletide</span>
+        </div>
+    </a>
+    `
+];
+const currentStars = []; // href values of current displayed stars
+const starsHTML = document.getElementsByClassName("christmas-star");
+const welcomeGrid = document
+    .getElementsByClassName("grid-container-welcome")[0];
 
-// -------------------------------------------------------------------- Christmas Cards
+// ------------------------------------------------------------- Christmas Cards
 
+/**
+ * Retrieves a single, random star HTML template literal
+ * @param {array} array template literal HTML star templates
+ * @returns {str} template literal of random star HTML
+ */
 function getRandomElement(array) {
-    let indexer = Math.floor(Math.random() * array.length);
-    return array[indexer];
+    return array[Math.floor(Math.random() * array.length)];
 }
 
+/**
+ * Randomly positions a star within the main welcome section
+ * @param {HTMLElement} element star anchor
+ */
 function randomPosition(element) {
     const winHeight = window.innerHeight;
     const winWidth = window.innerWidth;
     elemHeight = element.offsetHeight + 20;
+    // minimum top position
     headHeight = document.getElementsByClassName("header")[0].offsetHeight + 57;
+    // available y position
     range = winHeight - (headHeight + elemHeight);
     element.style.opacity = 1;
     element.style.top = `${Math.random() * range + headHeight}px`;
+    // prevent stars appearing too close to edges with + 60
     element.style.left = `${
-        Math.random() * winWidth * 0.775 + winWidth * 0.075}px`;
+        Math.random() * winWidth * 0.72 + 60}px`;
     if (window.innerWidth < 600) {
-        element.style.left = `${Math.random() * 80}vw`;
+        element.style.left = `${Math.random() * winWidth * 0.45 + 60}px`;
     }
 }
 
+/**
+ * Generate a new star anchor and position randomly
+ * Maximum stars displayed is current number of
+ * holidays minus 1
+ */
 function generateStar() {
-    if (currentStars.length > stars.length - 3
-        || currentStars.length > 7) // maximum stars for future development
-        {
-            currentStars.shift();
+    if (currentStars.length > stars.length - 2
+        // maximum stars for future development
+        || currentStars.length > 7) {
+        currentStars.shift();
+        starsHTML[0].parentNode.removeChild(starsHTML[0]);
     }
-    const randomStar = getRandomElement(stars);
-    if (!currentStars.includes(randomStar.href)){
-        randomPosition(randomStar);
-        currentStars.push(randomStar.href);
+    let randomStarTemplate = getRandomElement(stars);
+    let randomStar = document.createElement('a');
+    welcomeGrid.append(randomStar);
+    randomStar.outerHTML = randomStarTemplate;
+    newStar = starsHTML[starsHTML.length - 1];
+    if (!currentStars.includes(newStar.href)){
+        randomPosition(newStar);
+        currentStars.push(newStar.href);
+    } else {
+        welcomeGrid.removeChild(newStar);
     }
 }
 
 generateStar(); // initial star so no delay
 
 (function randomStars() {
-    
     setInterval(() => {
         generateStar();
     }, 8000);
+    // remove star after 3 animations
+    setInterval(() => {
+        currentStars.shift();
+        starsHTML[0].parentNode.removeChild(starsHTML[0]);
+    }, 24000);
 })();
 
 /* 
@@ -55,7 +134,10 @@ window.addEventListener("resize", () => {
     while (currentStars.length > 0) {
         currentStars.shift();
     }
-    for (let star of stars) {
+    while (starsHTML.length > 0) {
+        starsHTML[0].parentNode.removeChild(starsHTML[0]);
+    }
+    for (let star of starsHTML) {
         star.style.opacity = 0;
         star.style.left = 0;
         star.style.top = 0;

--- a/assets/js/index.js
+++ b/assets/js/index.js
@@ -18,14 +18,15 @@ function randomPosition(element) {
     range = winHeight - (headHeight + elemHeight);
     element.style.opacity = 1;
     element.style.top = `${Math.random() * range + headHeight}px`;
-    element.style.left = `${Math.random() * winWidth * 0.775 + winWidth * 0.075}px`;
+    element.style.left = `${
+        Math.random() * winWidth * 0.775 + winWidth * 0.075}px`;
     if (window.innerWidth < 600) {
         element.style.left = `${Math.random() * 80}vw`;
     }
 }
 
 function generateStar() {
-    if (currentStars.length > stars.length - 2
+    if (currentStars.length > stars.length - 3
         || currentStars.length > 7) // maximum stars for future development
         {
             currentStars.shift();
@@ -45,3 +46,18 @@ generateStar(); // initial star so no delay
         generateStar();
     }, 8000);
 })();
+
+/* 
+ * Hide stars and reset position to top left.
+ * This prevents overflow when resizing window.
+ */
+window.addEventListener("resize", () => {
+    while (currentStars.length > 0) {
+        currentStars.shift();
+    }
+    for (let star of stars) {
+        star.style.opacity = 0;
+        star.style.left = 0;
+        star.style.top = 0;
+    }
+});

--- a/index.html
+++ b/index.html
@@ -84,43 +84,7 @@
                     <span class="sr-only">Scroll to the next holiday</span>
                     <i class="fas fa-chevron-down"></i>
                 </a>
-
-                <a href="christmas.html" class="christmas-star">
-                    <span class="sr-only">Christmas</span>
-                    <div class="star tap-target tooltip">
-                        <span class="tooltiptext">Christmas</span>
-                    </div>
-                </a>
-                <a href="hanukkah.html" class="christmas-star">
-                    <span class="sr-only">Hanukkah</span>
-                    <div class="star tap-target tooltip">
-                        <span class="tooltiptext">Hanukkah</span>
-                    </div>
-                </a>
-                <a href="diwali.html" class="christmas-star">
-                    <span class="sr-only">Diwali</span>
-                    <div class="star tap-target tooltip">
-                        <span class="tooltiptext">Diwali</span>
-                    </div>
-                </a>
-                <a href="chinese-new-year.html" class="christmas-star">
-                    <span class="sr-only">Chinese New Year</span>
-                    <div class="star tap-target tooltip">
-                        <span class="tooltiptext">Chinese New Year</span>
-                    </div>
-                </a>
-                <a href="new-year.html" class="christmas-star">
-                    <span class="sr-only">New Year's Eve</span>
-                    <div class="star tap-target tooltip">
-                        <span class="tooltiptext">New Year's Eve</span>
-                    </div>
-                </a>
-                <a href="yuletide.html" class="christmas-star">
-                    <span class="sr-only">Yuletide</span>
-                    <div class="star tap-target tooltip">
-                        <span class="tooltiptext">Yuletide</span>
-                    </div>
-                </a>
+                <!-- dynamic stars inserted here in index.js -->
             </div>
 
             <div class="grid-container grid-container-holidays grid-odds" id="christmas">


### PR DESCRIPTION
## PR contains:
- Add dynamic position to BTT button to keep it above footer/quiz
- Modify stars to be generated and removed in JS to prevent 'tabbing' to invisible stars
- Positions modified to prevent overflow. On screens 400 <-> 600 width, right hand side will never
  spawn stars. Allowing them to spawn and preventing overflow causes issues with 'tabbing' to
  invisible DOM content.
- Remove stars after 3 animations (24000ms) to give impression of more random effect.

## Breaking changes
- None

## Screenshots
- None
